### PR TITLE
Fix pymodbus >= version 3.8.0 incompatibility

### DIFF
--- a/custom_components/heatapp_local/coordinator.py
+++ b/custom_components/heatapp_local/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
-from pymodbus.register_read_message import ReadHoldingRegistersResponse
+from pymodbus.pdu.register_message import ReadHoldingRegistersResponse
 
 from datetime import timedelta
 


### PR DESCRIPTION
pymodbus changed the path form pymodbus.read_register_message to pymodbus.pdu.read_message in versions >= 3.8.0